### PR TITLE
Improvements for Ubuntu 20.04 support

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -62,15 +62,20 @@ sudo pip install $BASEDIR/Python_Module
 ### reference: https://github.com/bitula/minipupper-dev/blob/main/scripts/minipupper.sh
 getent group gpio || sudo groupadd gpio && sudo gpasswd -a $(whoami) gpio
 getent group dialout || sudo groupadd dialout && sudo gpasswd -a $(whoami) dialout
+getent group spi || sudo groupadd spi && sudo gpasswd -a $(whoami) spi
 sudo tee /etc/udev/rules.d/99-minipupper-pwm.rules << EOF > /dev/null
 KERNEL=="pwmchip0", SUBSYSTEM=="pwm", RUN+="/usr/lib/udev/pwm-minipupper.sh"
 EOF
 sudo tee /etc/udev/rules.d/99-minipupper-gpio.rules << EOF > /dev/null
 KERNELS=="gpiochip0", SUBSYSTEM=="gpio", ACTION=="add", ATTR{label}=="pinctrl-bcm2711", RUN+="/usr/lib/udev/gpio-minipupper.sh"
+KERNEL=="gpiomem", OWNER="root", GROUP="gpio", MODE="0660"
 EOF
 sudo tee /etc/udev/rules.d/99-minipupper-nvmem.rules << EOF > /dev/null
 KERNEL=="3-00500", SUBSYSTEM=="nvmem", RUN+="/bin/chmod 666 /sys/bus/nvmem/devices/3-00500/nvmem"
 KERNEL=="3-00501", SUBSYSTEM=="nvmem", RUN+="/bin/chmod 666 /sys/bus/nvmem/devices/3-00501/nvmem"
+EOF
+sudo tee /etc/udev/rules.d/99-minipupper-spi.rules << EOF > /dev/null
+KERNEL=="spidev0.0", OWNER="root", GROUP="spi", MODE="0660"
 EOF
 
 sudo tee /usr/lib/udev/pwm-minipupper.sh << "EOF" > /dev/null

--- a/test.sh
+++ b/test.sh
@@ -49,7 +49,7 @@ check_result "Ready"
 
 echo 1500000 > /sys/class/pwm/pwmchip0/pwm4/duty_cycle
 sleep 2
-echo 2500000 > /sys/class/pwm/pwmchip0/pwm4/duty_cycle
+echo 2000000 > /sys/class/pwm/pwmchip0/pwm4/duty_cycle
 
 check_result "Did you see a leg moving"
 

--- a/test.sh
+++ b/test.sh
@@ -53,5 +53,12 @@ echo 2500000 > /sys/class/pwm/pwmchip0/pwm4/duty_cycle
 
 check_result "Did you see a leg moving"
 
+### Reset servo
+echo 0 > /sys/class/pwm/pwmchip0/pwm4/enable
+echo 0 > /sys/class/gpio/gpio25/value
+sleep 1
+echo 1 > /sys/class/pwm/pwmchip0/pwm4/enable
+echo 1 > /sys/class/gpio/gpio25/value
+
 echo "Your base installation looks OK"
 echo "You may now proceed to calibrate Minipupper"


### PR DESCRIPTION
1. Reset servo after test to turn torque off
1. Fix pwm range
1. Fix permission errors for LCD
    ```
    Traceback (most recent call last):
      File "test.py", line 20, in <module>
        main()
      File "test.py", line 10, in main
        disp = ST7789()
      File "/usr/local/lib/python3.8/dist-packages/MangDang/LCD/ST7789.py", line 155, in __init__
        self._spi = SPI.SpiDev(SPI_PORT, SPI_DEVICE, max_speed_hz=SPI_SPEED_HZ)
      File "/usr/local/lib/python3.8/dist-packages/MangDang/Adafruit_GPIO/SPI.py", line 42, in __init__
        self._device.open(port, device)
    PermissionError: [Errno 13] Permission denied
    ```
    
    ```
    Traceback (most recent call last):
      File "test.py", line 20, in <module>
        main()
      File "test.py", line 10, in main
        disp = ST7789()
      File "/usr/local/lib/python3.8/dist-packages/MangDang/LCD/ST7789.py", line 165, in __init__
        self._gpio.setup(self._dc, GPIO.OUT)
      File "/usr/local/lib/python3.8/dist-packages/MangDang/Adafruit_GPIO/GPIO.py", line 187, in setup
        self.rpi_gpio.setup(pin, self._dir_mapping[mode],
    RuntimeError: No access to /dev/mem.  Try running as root!
    ```